### PR TITLE
IronSourceMediationPlugin의 부정확한 Flag 사용 수정

### DIFF
--- a/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
+++ b/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
@@ -68,6 +68,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
     Log.d("IronSourceMediationPlugin", "onAttachedToEngine");
 
     if (!isPluginAttached) {
+      isPluginAttached = true
       channel = MethodChannel(flutterPluginBinding.binaryMessenger, "ironsource_mediation")
       channel.setMethodCallHandler(this)
       context=flutterPluginBinding.getApplicationContext()
@@ -78,9 +79,9 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     Log.d("IronSourceMediationPlugin", "onDetachedFromEngine");
 
-    // isPluginAttached=false
-    // channel.setMethodCallHandler(null)
-    // detachListeners()
+    isPluginAttached=false
+    channel.setMethodCallHandler(null)
+    detachListeners()
     // if (::channel.isInitialized) {
     //     channel.setMethodCallHandler(null)
     //     detachListeners()
@@ -684,7 +685,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
 
   /** region ActivityAware =======================================================================*/
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    isPluginAttached=true
+    // isPluginAttached=true
     activity = binding.activity
     if (activity is FlutterActivity)
     {
@@ -711,7 +712,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    isPluginAttached=true
+    // isPluginAttached=true
     if (activity is FlutterActivity)
     {
       activity = binding.activity as FlutterActivity

--- a/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
+++ b/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
@@ -64,6 +64,8 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   private var mLevelPlayInterstitialListener: LevelPlayInterstitialListener? = null
   private var mLevelPlayBannerListener: LevelPlayBannerListener? = null
 
+  private var isPluginAttached: Boolean=false
+  
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     Log.d("IronSourceMediationPlugin", "onAttachedToEngine");
 
@@ -769,7 +771,6 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
 
   companion object {
     val TAG = IronSourceMediationPlugin::class.java.simpleName
-    var isPluginAttached: Boolean=false
   }
 
   enum class BannerPosition(val value: Int) {


### PR DESCRIPTION
Background Service가 실행되면서, 전체 Plugin의 삭제 추가가 반복되는데, static 변수 및 불분명한 변수의 사용으로 플러그인 초기화가 정상적으로 되지 않는 문제를 수정하였습니다.