### PR TITLE
feat: IronSourceMediationPlugin이 Activity 붙어있을때만 초기화하도록 수정

### DIFF
--- a/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
+++ b/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
@@ -30,9 +30,10 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.BinaryMessenger
 import java.util.concurrent.Executors
 import kotlin.math.abs
-
+import java.util.concurrent.atomic.AtomicBoolean
 
 /** IronSourceMediationPlugin */
 class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, LifecycleObserver {
@@ -43,7 +44,6 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   private lateinit var channel: MethodChannel
   private var activity: Activity? = null
   private lateinit var context: Context
-
 
   // Banner related
   private var mBannerContainer: FrameLayout? = null
@@ -64,30 +64,30 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   private var mLevelPlayInterstitialListener: LevelPlayInterstitialListener? = null
   private var mLevelPlayBannerListener: LevelPlayBannerListener? = null
 
-  private var isPluginAttached: Boolean=false
-  
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    Log.d("IronSourceMediationPlugin", "onAttachedToEngine");
+  private lateinit var binaryMessenger: BinaryMessenger
+  private val CHANNEL_NAME = "ironsource_mediation"
 
-    if (!isPluginAttached) {
-      isPluginAttached = true
-      channel = MethodChannel(flutterPluginBinding.binaryMessenger, "ironsource_mediation")
-      channel.setMethodCallHandler(this)
-      context=flutterPluginBinding.getApplicationContext()
-      initListeners()
-    }
+  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    Log.d("IronSourceMediationPlugin", "onAttachedToEngine: Thread: ${Thread.currentThread().getName()}");
+    binaryMessenger = flutterPluginBinding.binaryMessenger
+    context = flutterPluginBinding.applicationContext
+  }
+
+  fun init() {
+    Log.d("IronSourceMediationPlugin", "init: Thread: ${Thread.currentThread().getName()}");
+    channel = MethodChannel(binaryMessenger, CHANNEL_NAME)
+    channel.setMethodCallHandler(this)
+    initListeners()
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    Log.d("IronSourceMediationPlugin", "onDetachedFromEngine");
-
-    isPluginAttached=false
-    channel.setMethodCallHandler(null)
-    detachListeners()
-    // if (::channel.isInitialized) {
-    //     channel.setMethodCallHandler(null)
-    //     detachListeners()
-    // }
+    Log.d("IronSourceMediationPlugin", "onDetachedFromEngine: Thread: ${Thread.currentThread().getName()}");
+     if (::channel.isInitialized) {
+         channel.setMethodCallHandler(null)
+         detachListeners()
+     }
+    binaryMessenger = null
+    context = null
   }
 
   /**
@@ -145,7 +145,6 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
    * Listener Reference Clean Up
    */
   private fun detachListeners() {
-    print("detachListeners");
     // RewardedVideo
     mRewardedVideoListener?.let { IronSource.removeRewardedVideoListener() }
     mRewardedVideoListener = null
@@ -687,8 +686,11 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
 
   /** region ActivityAware =======================================================================*/
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    // isPluginAttached=true
+    Log.d(TAG, "onAttachedToActivity: ${binding.activity}")
     activity = binding.activity
+    if (!::channel.isInitialized) {
+      init()
+    }
     if (activity is FlutterActivity)
     {
       (activity as FlutterActivity).lifecycle.addObserver(this)
@@ -701,6 +703,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
+    Log.d(TAG, "onDetachedFromActivityForConfigChanges: ${activity}")
     if (activity is FlutterActivity)
     {
       (activity as FlutterActivity).lifecycle.removeObserver(this)
@@ -714,7 +717,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    // isPluginAttached=true
+    Log.d(TAG, "onReattachedToActivityForConfigChanges: ${binding.activity}")
     if (activity is FlutterActivity)
     {
       activity = binding.activity as FlutterActivity
@@ -729,6 +732,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   }
 
   override fun onDetachedFromActivity() {
+    Log.d(TAG, "onDetachedFromActivity: ${activity}")
     if (activity is FlutterActivity)
     {
       (activity as FlutterActivity).lifecycle.removeObserver(this)
@@ -746,6 +750,7 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
    * Set FlutterActivity to listener instances
    */
   private fun setActivityToListeners(activity: Activity?) {
+    Log.d(TAG, "setActivityToListeners: $activity")
     mRewardedVideoListener?.activity = activity
     mInterstitialListener?.activity = activity
     mOfferWallListener?.activity = activity
@@ -760,11 +765,13 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   /** region LifeCycleObserver  ==================================================================*/
   @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
   fun onResume() {
+    Log.d(TAG, "onResume: ${activity}")
     activity?.apply { IronSource.onResume(this) }
   }
 
   @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
   fun onPause() {
+    Log.d(TAG, "onPause: ${activity}")
     activity?.apply { IronSource.onPause(this) }
   }
   // endregion
@@ -772,7 +779,6 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
   companion object {
     val TAG = IronSourceMediationPlugin::class.java.simpleName
   }
-
   enum class BannerPosition(val value: Int) {
     Top(0),
     Center(1),

--- a/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
+++ b/android/src/main/kotlin/com/ironSource/ironsource_mediation/IronSourceMediationPlugin.kt
@@ -33,7 +33,6 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.BinaryMessenger
 import java.util.concurrent.Executors
 import kotlin.math.abs
-import java.util.concurrent.atomic.AtomicBoolean
 
 /** IronSourceMediationPlugin */
 class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, LifecycleObserver {
@@ -86,8 +85,6 @@ class IronSourceMediationPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
          channel.setMethodCallHandler(null)
          detachListeners()
      }
-    binaryMessenger = null
-    context = null
   }
 
   /**


### PR DESCRIPTION
2024-03-20 17:17:26.354 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onAttachedToEngine: pluginState: NotInitialized, Thread: main
2024-03-20 17:17:26.368 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  setActivityToListeners: null
2024-03-20 17:17:26.368 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onAttachedToActivity: io.heybit.bitbunny.MainActivity@b204489
2024-03-20 17:17:26.371 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  setActivityToListeners: io.heybit.bitbunny.MainActivity@b204489
2024-03-20 17:17:26.458 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onResume: io.heybit.bitbunny.MainActivity@b204489
2024-03-20 17:17:30.984 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onAttachedToEngine: pluginState: NotInitialized, Thread: main
2024-03-20 17:17:30.985 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  setActivityToListeners: null
2024-03-20 17:17:50.213 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onPause: io.heybit.bitbunny.MainActivity@b204489
2024-03-20 17:18:45.799 23585-23585 IronSource...tionPlugin io.heybit.bitbunny.local             D  onResume: io.heybit.bitbunny.MainActivity@b204489

로그상으로 두번째 플러그인이 초기화될때 (background service에 사용되는 flutter engine에 붙는 plugin으로 추정), 동일한 이름으로 MethodChannel을 생성하고 있어서 문제가 되는게 아닌가싶어서, Activity에 붙었을때 초기화를 할 수 있도록 init 위치를 수정

